### PR TITLE
Removed ChatSecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A list of interesting and open source Android apps.
 - [Messaging](#messaging)
   - [Signal](#signal)
   - [Silence](#silence)
-  - [ChatSecure](#chatsecure)
   - [Telegram](#telegram)
   - [Conversations](#conversations)
   - [Kontalk](#kontalk)
@@ -129,14 +128,6 @@ Using Signal, you can communicate instantly while avoiding SMS fees, create grou
 [Silence](https://silence.im) (formerly SMSSecure) is an SMS/MMS application that allows you to protect your privacy while communicating with friends. Using Silence, you can send SMS messages and share media or attachments with complete privacy.
 
 [Github](https://github.com/SilenceIM/Silence) | [Google Play](https://play.google.com/store/apps/details?id=org.smssecure.smssecure) | [F-Droid](https://f-droid.org/repository/browse/?fdid=org.smssecure.smssecure)
-
-![ChatSecure](/img/chatsecure.png)
-
-### ChatSecure
-
-[ChatSecure](https://chatsecure.org) is a free and open source messaging app that features OTR encryption over XMPP. You can connect to your existing accounts on Facebook or Google, create new accounts on [public XMPP servers](https://xmpp.net/directory.php) (including via [Tor](https://www.torproject.org/)), or even [connect to your own server](http://arstechnica.com/information-technology/2014/03/how-to-set-up-your-own-private-instant-messaging-server) for extra security. Unlike other apps that keep you stuck in their walled garden, ChatSecure is fully interoperable with other clients that support OTR and XMPP, such as [Adium](https://www.adium.im), [Jitsi](https://jitsi.org), and [more](https://www.wikiwand.com/en/Off-the-Record_Messaging#/Client_support).
-
-[Github](https://github.com/ChatSecure/ChatSecure-iOS) | [Google Play](https://play.google.com/store/apps/details?id=info.guardianproject.otr.app.im)
 
 ![Telegram](/img/telegram.png)
 


### PR DESCRIPTION
https://chatsecure.org/blog/chatsecure-android-deprecated/